### PR TITLE
void_repos.py: add option to show as a new message in buffer list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Parsing of void-builder notices for the new format of buildbot messages.
 - Ability to display as a new message in the buffer list.
+### Fixed
+- Display when bots have alternative nicknames.
 
 
 ## [1.2.0] - 2023-02-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Configuration option for soju workaround.
 ### Changed
 - Parsing of void-builder notices for the new format of buildbot messages.
+- Ability to display as a new message in the buffer list.
 
 
 ## [1.2.0] - 2023-02-19

--- a/void_repos.py
+++ b/void_repos.py
@@ -39,7 +39,7 @@ def handle_sv_notice(word: list[str], word_eol: list[str], userdata):
 
 
 def handle_void(source: str, msg: str):
-    match source:
+    match source.rstrip("_^"):
         case "void-robot":
             bot = "Robot"
             parser = parse_robot

--- a/void_repos.py
+++ b/void_repos.py
@@ -22,6 +22,8 @@ __module_description__ = "Plugin for Void Linux's notification bots"
 debug = bool(hexchat.get_pluginpref("void_repos_debug"))
 # if unset, defaults to False
 workaround_soju = bool(hexchat.get_pluginpref("void_repos_sojuhack"))
+# if unset, defaults to False
+quiet = bool(hexchat.get_pluginpref("void_repos_quiet"))
 
 
 def handle_ch_notice(word: list[str], word_eol: list[str], userdata):
@@ -57,6 +59,8 @@ def handle_void(source: str, msg: str):
         hexchat.prnt(line2)
     if line3:
         hexchat.prnt(f"\00314{line3}")
+    if not quiet:
+        hexchat.command("GUI COLOR 2")
     return hexchat.EAT_HEXCHAT
 
 


### PR DESCRIPTION
defaults to acting as a new message, set `void_repos_quiet` in conf to make it act like a notice/join/part/nick change
