### PR TITLE
void_repos: update parsing logic for buildbot 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Configuration option for soju workaround.
+### Changed
+- Parsing of void-builder notices for the new format of buildbot messages.
 
 
 ## [1.2.0] - 2023-02-19


### PR DESCRIPTION
now looks like this:

![image](https://github.com/user-attachments/assets/58fac16a-40d1-4b66-9d28-3d90bf7eca71)
